### PR TITLE
Remove usage of deprecated functions

### DIFF
--- a/obridge-main/src/main/resources/PrimitiveTypeConverter.java.mustache
+++ b/obridge-main/src/main/resources/PrimitiveTypeConverter.java.mustache
@@ -1,8 +1,7 @@
 package {{packageName}};
 
 import oracle.jdbc.OracleConnection;
-import oracle.sql.ARRAY;
-import oracle.sql.ArrayDescriptor;
+import java.sql.Array;
 
 import javax.annotation.Generated;
 import java.math.BigDecimal;
@@ -23,13 +22,13 @@ public final class PrimitiveTypeConverter {
         OracleConnection connection = c.unwrap(OracleConnection.class);
         ArrayDescriptor arrayDescriptor = new ArrayDescriptor(typeName, connection);
         if (o == null) {
-            return new ARRAY(arrayDescriptor, connection, new Object[0]);
+            return connection.createOracleArray(typeName, new Object[0]);
         }
         List<Object> array = new ArrayList<Object>(o.size());
         for (Object e : o) {
             array.add(e);
         }
-        return new ARRAY(arrayDescriptor, connection, array.toArray());
+        return connection.createOracleArray(typeName, array.toArray());;;
     }
 
     public static <T> List<T> asList(Array array, Class<T> targetClass) throws SQLException {

--- a/obridge-main/src/main/resources/converter.mustache
+++ b/obridge-main/src/main/resources/converter.mustache
@@ -2,8 +2,7 @@ package {{converterPackageName}};
 
 import {{objectPackage}}.*;
 import oracle.jdbc.OracleConnection;
-import oracle.sql.ARRAY;
-import oracle.sql.ArrayDescriptor;
+import java.sql.Array;
 
 import javax.annotation.Generated;
 import java.math.BigDecimal;
@@ -38,10 +37,9 @@ public final class {{javaClassName}}Converter {
     public static Array getListArray(List<{{javaClassName}}> o, Connection c, String typeName) throws SQLException {
 
         OracleConnection connection = c.unwrap(OracleConnection.class);
-        ArrayDescriptor arrayDescriptor = new ArrayDescriptor(typeName, connection);
 
         if (o == null) {
-            return new ARRAY(arrayDescriptor, connection, new Object[0]);
+            return connection.createOracleArray(typeName, new Object[0]);
         }
 
         List<Object> array = new ArrayList<Object>(o.size());
@@ -50,7 +48,7 @@ public final class {{javaClassName}}Converter {
             array.add({{javaClassName}}Converter.getStruct(e, connection));
         }
 
-        return new ARRAY(arrayDescriptor, connection, array.toArray());
+        return connection.createOracleArray(typeName, array.toArray());
     }
 
     public static {{javaClassName}} getObject(Struct struct) throws SQLException {


### PR DESCRIPTION
Code, generated by the obridge, uses deprecated functions so I upgraded them to the new ones. No more deprecated warnings when compiling in 1.8.