### PR TITLE
Added functionality to query database object names from a user defined table

### DIFF
--- a/obridge-main/pom.xml
+++ b/obridge-main/pom.xml
@@ -111,9 +111,18 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
-                    <finalName>obridge</finalName>
+                    <finalName>obridge-${version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
+                <executions>
+                <execution>
+                    <id>make-assembly</id> 
+                    <phase>package</phase> <!-- bind to the packaging phase -->
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
             </plugin>
         </plugins>
         <resources>

--- a/obridge-main/src/main/java/org/obridge/OBridge.java
+++ b/obridge-main/src/main/java/org/obridge/OBridge.java
@@ -27,10 +27,7 @@ package org.obridge;
 import com.thoughtworks.xstream.XStream;
 import org.apache.commons.cli.*;
 import org.obridge.context.OBridgeConfiguration;
-import org.obridge.generators.ConverterObjectGenerator;
-import org.obridge.generators.EntityObjectGenerator;
-import org.obridge.generators.PackageObjectGenerator;
-import org.obridge.generators.ProcedureContextGenerator;
+import org.obridge.generators.*;
 import org.obridge.util.OBridgeException;
 import org.obridge.util.XStreamFactory;
 
@@ -113,6 +110,9 @@ public class OBridge {
     }
 
     public void generate(OBridgeConfiguration c) {
+        // populate objects table
+        PopulateObjectsTable.run(c);
+
         // generate objects
         EntityObjectGenerator.generate(c);
 

--- a/obridge-main/src/main/java/org/obridge/context/OBridgeConfiguration.java
+++ b/obridge-main/src/main/java/org/obridge/context/OBridgeConfiguration.java
@@ -42,6 +42,8 @@ public class OBridgeConfiguration {
     private Logging logging;
     private String packagesLike;
     private String sourceOwner;
+    private String sourcesTableProc;
+    private String sourcesTable;
 
     public String getPackagesLike() {
         if (packagesLike == null) {
@@ -100,5 +102,17 @@ public class OBridgeConfiguration {
 
     public void setLogging(Logging logging) {
         this.logging = logging;
+    }
+
+    public String getSourcesTable() {
+        return sourcesTable;
+    }
+
+    public void setSourcesTable(String sourcesTable) {
+        this.sourcesTable = sourcesTable;
+    }
+
+    public String getSourcesTableProc() {
+        return sourcesTableProc;
     }
 }

--- a/obridge-main/src/main/java/org/obridge/context/OBridgeConfiguration.java
+++ b/obridge-main/src/main/java/org/obridge/context/OBridgeConfiguration.java
@@ -34,6 +34,7 @@ package org.obridge.context;
 public class OBridgeConfiguration {
 
     public static final boolean GENERATE_SOURCE_FOR_PLSQL_TYPES = false;
+    public static final boolean ADD_ASSERT = false;
 
     private String jdbcUrl;
     private String sourceRoot;

--- a/obridge-main/src/main/java/org/obridge/context/OBridgeConfiguration.java
+++ b/obridge-main/src/main/java/org/obridge/context/OBridgeConfiguration.java
@@ -43,6 +43,7 @@ public class OBridgeConfiguration {
     private Logging logging;
     private String packagesLike;
     private String sourceOwner;
+    private String projectName;
     private String sourcesTableProc;
     private String sourcesTable;
 
@@ -116,4 +117,8 @@ public class OBridgeConfiguration {
     public String getSourcesTableProc() {
         return sourcesTableProc;
     }
+
+    public String getProjectName() { return projectName == null ? "default": projectName; }
+
+    public void setProjectName(String projectName) { this.projectName = projectName; }
 }

--- a/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
+++ b/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
@@ -124,8 +124,7 @@ public class ProcedureDao {
         if (sourcesTableWhere == null) {
             return result;
         }
-        result = replaceSourceTable(SOURCESTABLE, sourcesTableWhere);
-        return result;
+        return result.replace(SOURCESTABLE, sourcesTableWhere);
     }
 
     private String getAllProcedureQuery(String sourcesTable) {
@@ -144,7 +143,7 @@ public class ProcedureDao {
         if (sourcesTable != null) {
             sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') ";
         }
-        result = replaceSourceTable(SOURCESTABLE, sourcesTableWhere);
+        result = replaceSourceTable(result, sourcesTableWhere);
         return result;
     }
 

--- a/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
+++ b/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
@@ -38,7 +38,8 @@ import java.util.List;
  */
 public class ProcedureDao {
 
-    private static String SOURCESTABLE = "%sourcesTable%";
+    private static String SOURCES_TABLE = "%sourcesTable%";
+    private static String PROJECT_NAME = "%projectName%";
 
     private static final String GET_ALL_PROCEDURE =
             "Select object_name,\n" +
@@ -57,7 +58,7 @@ public class ProcedureDao {
                     "   And object_type = 'PACKAGE'\n" +
                     "   And object_name Like ?\n" +
                     "   And procedure_name Like ?\n" +
-                        SOURCESTABLE +
+                    SOURCES_TABLE +
                     "   And Not ((object_name, procedure_name, nvl(overload, -1)) In\n" +
                     "        (Select package_name, object_name, nvl(overload, -1)\n" +
                     "               From all_arguments\n" +
@@ -84,7 +85,7 @@ public class ProcedureDao {
                     "  From all_procedures t\n" +
                     " Where owner = ? and procedure_name Is Null\n" +
                     "   And object_type In ('PROCEDURE', 'FUNCTION')\n" +
-                        SOURCESTABLE +
+                    SOURCES_TABLE +
                     "   And Not ((object_name, procedure_name, nvl(overload, -1)) In\n" +
                     "        (Select object_name, package_name, nvl(overload, -1)\n" +
                     "               From all_arguments\n" +
@@ -111,7 +112,7 @@ public class ProcedureDao {
             + "         And not(pls_type is null and argument_name is null and data_type is null)"
             + "       Order By t.sequence) p\n";
 
-    private static final String GET_ALL_REAL_ORACLE_PACKAGE = "select object_name from all_objects where object_type = 'PACKAGE' and object_name like ? and owner = ? " +  SOURCESTABLE;
+    private static final String GET_ALL_REAL_ORACLE_PACKAGE = "select object_name from all_objects where object_type = 'PACKAGE' and object_name like ? and owner = ? " + SOURCES_TABLE;
 
     private JdbcTemplate jdbcTemplate;
 
@@ -119,52 +120,53 @@ public class ProcedureDao {
         jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
-    private String replaceSourceTable(String query, String sourcesTableWhere) {
+    private String replaceVariables(String query, String projectName, String sourcesTableWhere) {
         String result = query;
-        if (sourcesTableWhere == null) {
-            return result;
-        }
-        return result.replace(SOURCESTABLE, sourcesTableWhere);
+        String projectNameValue = projectName == null ? "" : projectName;
+        String sourcesTableWhereValue = sourcesTableWhere == null ? "" : sourcesTableWhere;
+        result = result.replace(SOURCES_TABLE, sourcesTableWhereValue).replace(PROJECT_NAME, "'" + projectNameValue + "'");
+        return result;
     }
 
-    private String getAllProcedureQuery(String sourcesTable) {
+    private String getAllProcedureQuery(String projectName, String sourcesTable) {
         String result = GET_ALL_PROCEDURE;
         String sourcesTableWhere = null;
         if (sourcesTable != null) {
-            sourcesTableWhere = " AND (procedure_name in (select object_name from " + sourcesTable + " where object_type = 'PROCEDURE')  or object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') )";
+            sourcesTableWhere = " AND (procedure_name in (select object_name from " + sourcesTable + " where project_name = " + PROJECT_NAME + " and object_type = 'PROCEDURE') " +
+                                " OR object_name in (select object_name from " + sourcesTable + " where  project_name = " + PROJECT_NAME + " and object_type = 'PACKAGE') )";
         }
-        result = replaceSourceTable(result, sourcesTableWhere);
+        result = replaceVariables(result, projectName, sourcesTableWhere);
         return result;
     }
 
-    private String getAllRealOraclePackageQuery(String sourcesTable) {
+    private String getAllRealOraclePackageQuery(String projectName, String sourcesTable) {
         String result = GET_ALL_REAL_ORACLE_PACKAGE;
         String sourcesTableWhere = null;
         if (sourcesTable != null) {
-            sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') ";
+            sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where project_name = " + PROJECT_NAME + " and object_type = 'PACKAGE') ";
         }
-        result = replaceSourceTable(result, sourcesTableWhere);
+        result = replaceVariables(result, projectName, sourcesTableWhere);
         return result;
     }
 
-    private String getAllSimpleFunctionAndProcedureQuery(String sourcesTable) {
+    private String getAllSimpleFunctionAndProcedureQuery(String projectName, String sourcesTable) {
         String result = GET_ALL_SIMPLE_FUNCTION_AND_PROCEDURE;
         String sourcesTableWhere = null;
         if (sourcesTable != null) {
-            sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where object_type = 'PROCEDURE') ";
+            sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where  project_name = " + PROJECT_NAME + " and object_type = 'PROCEDURE') ";
         }
-        return replaceSourceTable(result, sourcesTableWhere);
+        return replaceVariables(result, projectName, sourcesTableWhere);
     }
 
-    public List<Procedure> getAllProcedure(String nameFilter, String owner, String sourcesTable) {
-        List<Procedure> allProcedures = getAllProcedure(nameFilter, "", owner, sourcesTable);
-        allProcedures.addAll(getAllSimpleFunctionAndProcedure(owner, sourcesTable));
+    public List<Procedure> getAllProcedure(String nameFilter, String owner, String projectName, String sourcesTable) {
+        List<Procedure> allProcedures = getAllProcedure(nameFilter, "", owner, projectName, sourcesTable);
+        allProcedures.addAll(getAllSimpleFunctionAndProcedure(owner, projectName, sourcesTable));
         return allProcedures;
     }
 
-    public List<Procedure> getAllSimpleFunctionAndProcedure(String owner, String sourcesTable) {
+    public List<Procedure> getAllSimpleFunctionAndProcedure(String owner, String projectName, String sourcesTable) {
         return jdbcTemplate.query(
-                getAllSimpleFunctionAndProcedureQuery(sourcesTable),
+                getAllSimpleFunctionAndProcedureQuery(projectName, sourcesTable),
                 (resultSet, i) -> new Procedure.Builder()
                         .objectName("")
                         .procedureName(resultSet.getString("object_name"))
@@ -178,7 +180,7 @@ public class ProcedureDao {
 
     }
 
-    public List<Procedure> getAllProcedure(String packageName, String procedureName, String owner, String sourcesTable) {
+    public List<Procedure> getAllProcedure(String packageName, String procedureName, String owner, String projectName, String sourcesTable) {
         String packageNameFilter;
         String procedureNameFilter;
 
@@ -196,7 +198,7 @@ public class ProcedureDao {
 
 
         return jdbcTemplate.query(
-                getAllProcedureQuery(sourcesTable),
+                getAllProcedureQuery(projectName, sourcesTable),
                 (resultSet, i) -> new Procedure.Builder()
                         .objectName(resultSet.getString("object_name"))
                         .procedureName(resultSet.getString("procedure_name"))
@@ -225,11 +227,11 @@ public class ProcedureDao {
 
     }
 
-    public List<OraclePackage> getAllPackages(String nameFilter, String owner, String sourcesTable) {
+    public List<OraclePackage> getAllPackages(String nameFilter, String owner, String projectName, String sourcesTable) {
         String realNameFilter = getNameFilter(nameFilter);
 
-        List<OraclePackage> allPackage = getAllRealOraclePackage(realNameFilter, owner, sourcesTable);
-        allPackage.add(getAllStandaloneProcedureAndFunction(owner, sourcesTable));
+        List<OraclePackage> allPackage = getAllRealOraclePackage(realNameFilter, owner, projectName, sourcesTable);
+        allPackage.add(getAllStandaloneProcedureAndFunction(owner, projectName, sourcesTable));
         return allPackage;
     }
 
@@ -241,18 +243,18 @@ public class ProcedureDao {
         return realNameFilter;
     }
 
-    private OraclePackage getAllStandaloneProcedureAndFunction(String owner, String sourcesTable) {
+    private OraclePackage getAllStandaloneProcedureAndFunction(String owner, String projectName, String sourcesTable) {
         OraclePackage oraclePackage = new OraclePackage();
         oraclePackage.setName("PROCEDURES_AND_FUNCTIONS");
-        oraclePackage.setProcedureList(getAllSimpleFunctionAndProcedure(owner, sourcesTable));
+        oraclePackage.setProcedureList(getAllSimpleFunctionAndProcedure(owner, projectName, sourcesTable));
         return oraclePackage;
     }
 
-    protected List<OraclePackage> getAllRealOraclePackage(String nameFilter, String owner, String sourcesTable) {
-        return jdbcTemplate.query(getAllRealOraclePackageQuery(sourcesTable), (resultSet, i) -> {
+    protected List<OraclePackage> getAllRealOraclePackage(String nameFilter, String owner, String projectName, String sourcesTable) {
+        return jdbcTemplate.query(getAllRealOraclePackageQuery(projectName, sourcesTable), (resultSet, i) -> {
             OraclePackage p = new OraclePackage();
             p.setName(resultSet.getString("object_name"));
-            p.setProcedureList(getAllProcedure(resultSet.getString("object_name"), owner, sourcesTable));
+            p.setProcedureList(getAllProcedure(resultSet.getString("object_name"), owner, projectName, sourcesTable));
             return p;
         }, getNameFilter(nameFilter), owner);
     }

--- a/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
+++ b/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
@@ -66,7 +66,7 @@ public class ProcedureDao {
                     "                 Or (data_type = 'PL/SQL RECORD' " +
                     (OBridgeConfiguration.GENERATE_SOURCE_FOR_PLSQL_TYPES ? "And type_name Is Null" : "") +
                     ")))\n" +
-                    "    Or procedure_name = 'ASSERT'";
+                    (OBridgeConfiguration.ADD_ASSERT ? "Or procedure_name = 'ASSERT'" : "") ;
 
 
     private static final String GET_ALL_SIMPLE_FUNCTION_AND_PROCEDURE =
@@ -93,7 +93,7 @@ public class ProcedureDao {
                     "                 Or (data_type = 'PL/SQL RECORD' " +
                     (OBridgeConfiguration.GENERATE_SOURCE_FOR_PLSQL_TYPES ? "And type_name Is Null" : "") +
                     "))))\n" +
-                    "    Or procedure_name = 'ASSERT'";
+                    (OBridgeConfiguration.ADD_ASSERT ? "Or procedure_name = 'ASSERT'" : "") ;
 
 
     private static final String GET_PROCEDURE_ARGUMENTS = "  select argument_name," +
@@ -124,7 +124,8 @@ public class ProcedureDao {
         if (sourcesTableWhere == null) {
             return result;
         }
-        return result.replace(SOURCESTABLE, sourcesTableWhere);
+        result = replaceSourceTable(SOURCESTABLE, sourcesTableWhere);
+        return result;
     }
 
     private String getAllProcedureQuery(String sourcesTable) {
@@ -133,7 +134,8 @@ public class ProcedureDao {
         if (sourcesTable != null) {
             sourcesTableWhere = " AND (procedure_name in (select object_name from " + sourcesTable + " where object_type = 'PROCEDURE')  or object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') )";
         }
-        return replaceSourceTable(result, sourcesTableWhere);
+        result = replaceSourceTable(result, sourcesTableWhere);
+        return result;
     }
 
     private String getAllRealOraclePackageQuery(String sourcesTable) {
@@ -142,7 +144,8 @@ public class ProcedureDao {
         if (sourcesTable != null) {
             sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') ";
         }
-        return replaceSourceTable(result, sourcesTableWhere);
+        result = replaceSourceTable(SOURCESTABLE, sourcesTableWhere);
+        return result;
     }
 
     private String getAllSimpleFunctionAndProcedureQuery(String sourcesTable) {

--- a/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
+++ b/obridge-main/src/main/java/org/obridge/dao/ProcedureDao.java
@@ -111,7 +111,7 @@ public class ProcedureDao {
             + "         And not(pls_type is null and argument_name is null and data_type is null)"
             + "       Order By t.sequence) p\n";
 
-    private static final String GET_ALL_REAL_ORACLE_PACKAGE = "select object_name from all_objects where object_type = 'PACKAGE' and object_name like ? and owner = ?";
+    private static final String GET_ALL_REAL_ORACLE_PACKAGE = "select object_name from all_objects where object_type = 'PACKAGE' and object_name like ? and owner = ? " +  SOURCESTABLE;
 
     private JdbcTemplate jdbcTemplate;
 
@@ -119,37 +119,39 @@ public class ProcedureDao {
         jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
+    private String replaceSourceTable(String query, String sourcesTableWhere) {
+        String result = query;
+        if (sourcesTableWhere == null) {
+            return result;
+        }
+        return result.replace(SOURCESTABLE, sourcesTableWhere);
+    }
+
     private String getAllProcedureQuery(String sourcesTable) {
         String result = GET_ALL_PROCEDURE;
-        String sourcesTableWhere;
-        if (sourcesTable == null) {
-            sourcesTableWhere = "";
-        } else {
+        String sourcesTableWhere = null;
+        if (sourcesTable != null) {
             sourcesTableWhere = " AND (procedure_name in (select object_name from " + sourcesTable + " where object_type = 'PROCEDURE')  or object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') )";
         }
-        result = result.replace(SOURCESTABLE, sourcesTableWhere);
-        return result;
+        return replaceSourceTable(result, sourcesTableWhere);
     }
 
     private String getAllRealOraclePackageQuery(String sourcesTable) {
         String result = GET_ALL_REAL_ORACLE_PACKAGE;
-        String sourcesTableWhere;
+        String sourcesTableWhere = null;
         if (sourcesTable != null) {
-            result += " AND object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') ";
+            sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where object_type = 'PACKAGE') ";
         }
-        return result;
+        return replaceSourceTable(result, sourcesTableWhere);
     }
 
     private String getAllSimpleFunctionAndProcedureQuery(String sourcesTable) {
         String result = GET_ALL_SIMPLE_FUNCTION_AND_PROCEDURE;
-        String sourcesTableWhere;
-        if (sourcesTable == null) {
-            sourcesTableWhere = "";
-        } else {
+        String sourcesTableWhere = null;
+        if (sourcesTable != null) {
             sourcesTableWhere = " AND object_name in (select object_name from " + sourcesTable + " where object_type = 'PROCEDURE') ";
         }
-        result = result.replace(SOURCESTABLE, sourcesTableWhere);
-        return result;
+        return replaceSourceTable(result, sourcesTableWhere);
     }
 
     public List<Procedure> getAllProcedure(String nameFilter, String owner, String sourcesTable) {

--- a/obridge-main/src/main/java/org/obridge/dao/TypeDao.java
+++ b/obridge-main/src/main/java/org/obridge/dao/TypeDao.java
@@ -89,7 +89,7 @@ public class TypeDao {
         String sourcesTable = c != null ? c.getSourcesTable() : null;
         String query = "SELECT type_name FROM all_types WHERE typecode = 'OBJECT' and owner = '" + c.getSourceOwner() + "'";
         if (sourcesTable != null) {
-            query += " AND type_name in (SELECT object_name from " + sourcesTable + " where object_type = 'TYPE')";
+            query += " AND type_name in (SELECT object_name from " + sourcesTable + " where object_type = 'TYPE' and project_name='" + c.getProjectName() + "')";
         }
         return jdbcTemplate.queryForList(query);
     }

--- a/obridge-main/src/main/java/org/obridge/dao/TypeDao.java
+++ b/obridge-main/src/main/java/org/obridge/dao/TypeDao.java
@@ -24,6 +24,7 @@
 
 package org.obridge.dao;
 
+import org.obridge.context.OBridgeConfiguration;
 import org.obridge.model.data.TypeAttribute;
 import org.obridge.util.jdbc.JdbcTemplate;
 
@@ -81,8 +82,13 @@ public class TypeDao {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
-    public List<String> getTypeList() {
-        return jdbcTemplate.queryForList("SELECT type_name FROM user_types WHERE typecode = 'OBJECT'");
+    public List<String> getTypeList(OBridgeConfiguration c) {
+        String sourcesTable = c != null ? c.getSourcesTable() : null;
+        String query = "SELECT type_name FROM user_types WHERE typecode = 'OBJECT'";
+        if (sourcesTable != null) {
+            query += " AND type_name in (SELECT object_name from " + sourcesTable + " where object_type = 'TYPE')";
+        }
+        return jdbcTemplate.queryForList(query);
     }
 
     public List<TypeAttribute> getTypeAttributes(String typeName) {

--- a/obridge-main/src/main/java/org/obridge/dao/TypeDao.java
+++ b/obridge-main/src/main/java/org/obridge/dao/TypeDao.java
@@ -40,7 +40,7 @@ public class TypeDao {
     private static final String GET_TYPE_ATTRIBUTES = "Select attr_name,\n" +
             "       attr_type_name,\n" +
             "       attr_no,\n" +
-            "       nvl(nvl(scale, (Select scale From user_coll_types t Where t.type_name = aa.attr_type_name)), -1) data_scale,\n" +
+            "       nvl(nvl(scale, (Select scale From all_coll_types t Where t.type_name = aa.attr_type_name and t.owner=aa.owner)), -1) data_scale,\n" +
             "       Case\n" +
             "         When attr_type_owner Is Not Null Then\n" +
             "          1\n" +
@@ -48,9 +48,10 @@ public class TypeDao {
             "          0\n" +
             "       End multi_type,\n" +
             "       bb.typecode,\n" +
-            "       (Select elem_type_name From user_coll_types t Where t.type_name = aa.attr_type_name) collection_base_type\n" +
-            "  From user_type_attrs aa, user_types bb\n" +
+            "       (Select elem_type_name From all_coll_types t Where t.type_name = aa.attr_type_name and t.owner=aa.owner) collection_base_type\n" +
+            "  From all_type_attrs aa, all_types bb\n" +
             " Where upper(aa.type_name) = ?\n" +
+            " and aa.owner = bb.owner(+) and aa.owner = ?\n" +
             "   And aa.attr_type_name = bb.type_name(+)\n" +
             " Order By attr_no Asc";
 
@@ -64,15 +65,17 @@ public class TypeDao {
                     "                        bb.typecode typecode,\n" +
                     "                        Null collection_base_type\n" +
                     "          From (Select t.*\n" +
-                    "                  From user_arguments t\n" +
+                    "                  From all_arguments t\n" +
                     "                 Where t.type_name || '_' || t.type_subname = ?\n" +
+                    "                   AND t.owner = ?\n" +
                     "                   And rownum < 2) m\n" +
-                    "          Left Join (Select * From user_arguments t Where data_level = 1) d\n" +
+                    "          Left Join (Select * From all_arguments t Where data_level = 1 and t.owner=?) d\n" +
                     "            On m.object_name = d.object_name\n" +
                     "           And m.package_name = d.package_name\n" +
                     "           And nvl(m.overload, -1) = nvl(d.overload, -1)\n" +
-                    "          Left Join user_types bb\n" +
+                    "          Left Join all_types bb\n" +
                     "            On d.data_type = bb.type_name)\n" +
+                    "          where bb.owner=?\n" +
                     " Order By attr_no";
 
 
@@ -84,18 +87,18 @@ public class TypeDao {
 
     public List<String> getTypeList(OBridgeConfiguration c) {
         String sourcesTable = c != null ? c.getSourcesTable() : null;
-        String query = "SELECT type_name FROM user_types WHERE typecode = 'OBJECT'";
+        String query = "SELECT type_name FROM all_types WHERE typecode = 'OBJECT' and owner = '" + c.getSourceOwner() + "'";
         if (sourcesTable != null) {
             query += " AND type_name in (SELECT object_name from " + sourcesTable + " where object_type = 'TYPE')";
         }
         return jdbcTemplate.queryForList(query);
     }
 
-    public List<TypeAttribute> getTypeAttributes(String typeName) {
+    public List<TypeAttribute> getTypeAttributes(String typeName, String owner) {
 
         return jdbcTemplate.query(
                 GET_TYPE_ATTRIBUTES,
-                new Object[]{typeName.toUpperCase()}, (resultSet, i) -> new TypeAttribute(
+                new Object[]{typeName.toUpperCase(), owner}, (resultSet, i) -> new TypeAttribute(
                         resultSet.getString("attr_name"),
                         resultSet.getString("attr_type_name"),
                         resultSet.getInt("attr_no"),
@@ -107,16 +110,16 @@ public class TypeDao {
         );
     }
 
-    public List<String> getEmbeddedTypeList() {
+    public List<String> getEmbeddedTypeList(String owner) {
         return jdbcTemplate.queryForList("Select Distinct type_name || '_' || type_subname\n" +
-                "  From user_arguments t\n" +
-                " Where type_subname Is Not Null");
+                "  From all_arguments t\n" +
+                " Where type_subname Is Not Null and owner = '" + owner + "'");
     }
 
-    public List<TypeAttribute> getEmbeddedTypeAttributes(String typeName) {
+    public List<TypeAttribute> getEmbeddedTypeAttributes(String typeName, String owner) {
 
         return jdbcTemplate.query(GET_EMBEDDED_TYPE_ATTRIBUTES,
-                new Object[]{typeName.toUpperCase()}, (resultSet, i) -> new TypeAttribute(
+                new Object[]{typeName.toUpperCase(), owner, owner, owner}, (resultSet, i) -> new TypeAttribute(
                         resultSet.getString("attr_name"),
                         resultSet.getString("attr_type_name"),
                         resultSet.getInt("attr_no"),

--- a/obridge-main/src/main/java/org/obridge/generators/ConverterObjectGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/ConverterObjectGenerator.java
@@ -58,13 +58,13 @@ public final class ConverterObjectGenerator {
 
             List<String> types = typeDao.getTypeList(c);
             for (String typeName : types) {
-                generateType(packageName, objectPackage, outputDir, typeName, typeDao.getTypeAttributes(typeName));
+                generateType(packageName, objectPackage, outputDir, typeName, typeDao.getTypeAttributes(typeName, c.getSourceOwner()));
             }
 
             if (OBridgeConfiguration.GENERATE_SOURCE_FOR_PLSQL_TYPES) {
-                List<String> embeddedTypes = typeDao.getEmbeddedTypeList();
+                List<String> embeddedTypes = typeDao.getEmbeddedTypeList(c.getSourceOwner());
                 for (String typeName : embeddedTypes) {
-                    generateType(packageName, objectPackage, outputDir, typeName, typeDao.getEmbeddedTypeAttributes(typeName));
+                    generateType(packageName, objectPackage, outputDir, typeName, typeDao.getEmbeddedTypeAttributes(typeName, c.getSourceOwner()));
                 }
             }
 

--- a/obridge-main/src/main/java/org/obridge/generators/ConverterObjectGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/ConverterObjectGenerator.java
@@ -56,7 +56,7 @@ public final class ConverterObjectGenerator {
 
             TypeDao typeDao = new TypeDao(DataSourceProvider.getDataSource(c.getJdbcUrl()));
 
-            List<String> types = typeDao.getTypeList();
+            List<String> types = typeDao.getTypeList(c);
             for (String typeName : types) {
                 generateType(packageName, objectPackage, outputDir, typeName, typeDao.getTypeAttributes(typeName));
             }

--- a/obridge-main/src/main/java/org/obridge/generators/EntityObjectGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/EntityObjectGenerator.java
@@ -56,7 +56,7 @@ public final class EntityObjectGenerator {
 
             TypeDao typeDao = new TypeDao(DataSourceProvider.getDataSource(c.getJdbcUrl()));
 
-            List<String> types = typeDao.getTypeList();
+            List<String> types = typeDao.getTypeList(c);
             for (String typeName : types) {
                 generateEntityObject(packageName, outputDir, typeName, typeDao.getTypeAttributes(typeName));
             }

--- a/obridge-main/src/main/java/org/obridge/generators/EntityObjectGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/EntityObjectGenerator.java
@@ -58,7 +58,7 @@ public final class EntityObjectGenerator {
 
             List<String> types = typeDao.getTypeList(c);
             for (String typeName : types) {
-                generateEntityObject(packageName, outputDir, typeName, typeDao.getTypeAttributes(typeName));
+                generateEntityObject(packageName, outputDir, typeName, typeDao.getTypeAttributes(typeName, c.getSourceOwner()));
             }
 
             if (types.size() == 0) {
@@ -66,9 +66,9 @@ public final class EntityObjectGenerator {
             }
 
             if (OBridgeConfiguration.GENERATE_SOURCE_FOR_PLSQL_TYPES) {
-                List<String> embeddedTypes = typeDao.getEmbeddedTypeList();
+                List<String> embeddedTypes = typeDao.getEmbeddedTypeList(c.getSourceOwner());
                 for (String typeName : embeddedTypes) {
-                    generateEntityObject(packageName, outputDir, typeName, typeDao.getEmbeddedTypeAttributes(typeName));
+                    generateEntityObject(packageName, outputDir, typeName, typeDao.getEmbeddedTypeAttributes(typeName, c.getSourceOwner()));
                 }
             }
 

--- a/obridge-main/src/main/java/org/obridge/generators/PackageObjectGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/PackageObjectGenerator.java
@@ -67,7 +67,7 @@ public final class PackageObjectGenerator {
                 }
             }
 
-            List<OraclePackage> allPackages = new ProcedureDao(DataSourceProvider.getDataSource(c.getJdbcUrl())).getAllPackages(c.getPackagesLike(), c.getSourceOwner(), c.getSourcesTable());
+            List<OraclePackage> allPackages = new ProcedureDao(DataSourceProvider.getDataSource(c.getJdbcUrl())).getAllPackages(c.getPackagesLike(), c.getSourceOwner(), c.getProjectName(), c.getSourcesTable());
 
             for (OraclePackage oraclePackage : allPackages) {
                 oraclePackage.setJavaPackageName(packageName);

--- a/obridge-main/src/main/java/org/obridge/generators/PackageObjectGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/PackageObjectGenerator.java
@@ -67,7 +67,7 @@ public final class PackageObjectGenerator {
                 }
             }
 
-            List<OraclePackage> allPackages = new ProcedureDao(DataSourceProvider.getDataSource(c.getJdbcUrl())).getAllPackages(c.getPackagesLike(), c.getSourceOwner());
+            List<OraclePackage> allPackages = new ProcedureDao(DataSourceProvider.getDataSource(c.getJdbcUrl())).getAllPackages(c.getPackagesLike(), c.getSourceOwner(), c.getSourcesTable());
 
             for (OraclePackage oraclePackage : allPackages) {
                 oraclePackage.setJavaPackageName(packageName);

--- a/obridge-main/src/main/java/org/obridge/generators/PopulateObjectsTable.java
+++ b/obridge-main/src/main/java/org/obridge/generators/PopulateObjectsTable.java
@@ -1,0 +1,28 @@
+package org.obridge.generators;
+
+import org.obridge.context.OBridgeConfiguration;
+import org.obridge.util.DataSourceProvider;
+import org.obridge.util.OBridgeException;
+
+import javax.sql.DataSource;
+import java.beans.PropertyVetoException;
+import java.io.IOException;
+import java.sql.CallableStatement;
+
+public class PopulateObjectsTable {
+
+    public static void run(OBridgeConfiguration c) {
+        String sourcesTableProc = c.getSourcesTableProc();
+        if (sourcesTableProc == null) {
+            return;
+        }
+        sourcesTableProc = "begin " + sourcesTableProc + "; end;";
+        try {
+            DataSource datasource = DataSourceProvider.getDataSource(c.getJdbcUrl());
+            CallableStatement statement = datasource.getConnection().prepareCall(sourcesTableProc);
+            statement.execute();
+        } catch (Exception e) {
+            throw new OBridgeException(e);
+        }
+    }
+}

--- a/obridge-main/src/main/java/org/obridge/generators/PopulateObjectsTable.java
+++ b/obridge-main/src/main/java/org/obridge/generators/PopulateObjectsTable.java
@@ -13,13 +13,15 @@ public class PopulateObjectsTable {
 
     public static void run(OBridgeConfiguration c) {
         String sourcesTableProc = c.getSourcesTableProc();
+        String projectName = c.getProjectName();
         if (sourcesTableProc == null) {
             return;
         }
-        sourcesTableProc = "begin " + sourcesTableProc + "; end;";
+        sourcesTableProc = "begin " + sourcesTableProc + "(?); end;";
         try {
             DataSource datasource = DataSourceProvider.getDataSource(c.getJdbcUrl());
             CallableStatement statement = datasource.getConnection().prepareCall(sourcesTableProc);
+            statement.setString(1, projectName);
             statement.execute();
         } catch (Exception e) {
             throw new OBridgeException(e);

--- a/obridge-main/src/main/java/org/obridge/generators/ProcedureContextGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/ProcedureContextGenerator.java
@@ -57,7 +57,7 @@ public final class ProcedureContextGenerator {
 
             ProcedureDao procedureDao = new ProcedureDao(DataSourceProvider.getDataSource(c.getJdbcUrl()));
 
-            List<Procedure> allProcedures = procedureDao.getAllProcedure(c.getPackagesLike(), c.getSourceOwner());
+            List<Procedure> allProcedures = procedureDao.getAllProcedure(c.getPackagesLike(), c.getSourceOwner(), c.getSourcesTable());
 
             for (Procedure p : allProcedures) {
                 generateProcedureContext(packageName, objectPackage, outputDir, p);

--- a/obridge-main/src/main/java/org/obridge/generators/ProcedureContextGenerator.java
+++ b/obridge-main/src/main/java/org/obridge/generators/ProcedureContextGenerator.java
@@ -57,7 +57,7 @@ public final class ProcedureContextGenerator {
 
             ProcedureDao procedureDao = new ProcedureDao(DataSourceProvider.getDataSource(c.getJdbcUrl()));
 
-            List<Procedure> allProcedures = procedureDao.getAllProcedure(c.getPackagesLike(), c.getSourceOwner(), c.getSourcesTable());
+            List<Procedure> allProcedures = procedureDao.getAllProcedure(c.getPackagesLike(), c.getSourceOwner(), c.getProjectName(), c.getSourcesTable());
 
             for (Procedure p : allProcedures) {
                 generateProcedureContext(packageName, objectPackage, outputDir, p);

--- a/obridge-main/src/test/java/org/obridge/dao/ProcedureDaoTest.java
+++ b/obridge-main/src/test/java/org/obridge/dao/ProcedureDaoTest.java
@@ -24,7 +24,7 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void testGetAllProcedures() {
-        List<Procedure> allProcedures = procedureDao.getAllProcedure("", "OBRIDGE", null);
+        List<Procedure> allProcedures = procedureDao.getAllProcedure("", "OBRIDGE", null, null);
         Collection<String> procedureNames = FuncUtils.pluck("storedProcedureClassName", String.class, allProcedures);
         Assert.assertTrue(procedureNames.contains("SimpleProceduresA"));
         Assert.assertTrue(procedureNames.contains("SimpleProceduresOverload1"));
@@ -33,7 +33,7 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void testGetProcedureArguments() {
-        List<OraclePackage> allPackages = procedureDao.getAllPackages(null, "OBRIDGE", null);
+        List<OraclePackage> allPackages = procedureDao.getAllPackages(null, "OBRIDGE", null, null);
         Assert.assertTrue(allPackages.size() > 0);
 
         for (OraclePackage p : allPackages) {
@@ -44,13 +44,13 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void testGetAllSimpleProcedureAndFunction() {
-        List<Procedure> procs = procedureDao.getAllSimpleFunctionAndProcedure("OBRIDGE", "");
+        List<Procedure> procs = procedureDao.getAllSimpleFunctionAndProcedure("OBRIDGE", null, null);
         System.out.println(procs);
     }
 
     @Test
     public void testAllPckNoFilter() {
-        List<OraclePackage> allPackages = procedureDao.getAllPackages("ABCDE", "OBRIDGE", "");
+        List<OraclePackage> allPackages = procedureDao.getAllPackages("ABCDE", "OBRIDGE", null, null);
         Assert.assertTrue(allPackages.size() == 1);
 
     }
@@ -64,7 +64,7 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void getAllPackage() {
-        List<OraclePackage> obridge = procedureDao.getAllPackages("", "OBRIDGE", null);
+        List<OraclePackage> obridge = procedureDao.getAllPackages("", "OBRIDGE", null, null);
         Assert.assertTrue(obridge.size() > 0);
 
     }

--- a/obridge-main/src/test/java/org/obridge/dao/ProcedureDaoTest.java
+++ b/obridge-main/src/test/java/org/obridge/dao/ProcedureDaoTest.java
@@ -24,7 +24,7 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void testGetAllProcedures() {
-        List<Procedure> allProcedures = procedureDao.getAllProcedure("", "OBRIDGE");
+        List<Procedure> allProcedures = procedureDao.getAllProcedure("", "OBRIDGE", null);
         Collection<String> procedureNames = FuncUtils.pluck("storedProcedureClassName", String.class, allProcedures);
         Assert.assertTrue(procedureNames.contains("SimpleProceduresA"));
         Assert.assertTrue(procedureNames.contains("SimpleProceduresOverload1"));
@@ -33,7 +33,7 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void testGetProcedureArguments() {
-        List<OraclePackage> allPackages = procedureDao.getAllPackages(null, "OBRIDGE");
+        List<OraclePackage> allPackages = procedureDao.getAllPackages(null, "OBRIDGE", null);
         Assert.assertTrue(allPackages.size() > 0);
 
         for (OraclePackage p : allPackages) {
@@ -44,13 +44,13 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void testGetAllSimpleProcedureAndFunction() {
-        List<Procedure> procs = procedureDao.getAllSimpleFunctionAndProcedure("OBRIDGE");
+        List<Procedure> procs = procedureDao.getAllSimpleFunctionAndProcedure("OBRIDGE", "");
         System.out.println(procs);
     }
 
     @Test
     public void testAllPckNoFilter() {
-        List<OraclePackage> allPackages = procedureDao.getAllPackages("ABCDE", "OBRIDGE");
+        List<OraclePackage> allPackages = procedureDao.getAllPackages("ABCDE", "OBRIDGE", "");
         Assert.assertTrue(allPackages.size() == 1);
 
     }
@@ -64,7 +64,7 @@ public class ProcedureDaoTest extends BaseTest {
 
     @Test
     public void getAllPackage() {
-        List<OraclePackage> obridge = procedureDao.getAllPackages("", "OBRIDGE");
+        List<OraclePackage> obridge = procedureDao.getAllPackages("", "OBRIDGE", null);
         Assert.assertTrue(obridge.size() > 0);
 
     }

--- a/obridge-main/src/test/java/org/obridge/dao/TypeDaoTest.java
+++ b/obridge-main/src/test/java/org/obridge/dao/TypeDaoTest.java
@@ -36,7 +36,7 @@ public class TypeDaoTest extends BaseTest {
 
     @Test
     public void testGetTypeAttributes() {
-        List<TypeAttribute> typeAttributes = typeDao.getTypeAttributes(SAMPLE_TYPE_ONE);
+        List<TypeAttribute> typeAttributes = typeDao.getTypeAttributes(SAMPLE_TYPE_ONE, "OBRIDGE");
         Assert.assertEquals(9, typeAttributes.size());
         Assert.assertEquals("attrVarchar", typeAttributes.get(0).getJavaPropertyName());
         Assert.assertEquals("String", typeAttributes.get(0).getJavaDataType());
@@ -45,7 +45,7 @@ public class TypeDaoTest extends BaseTest {
 
     @Test
     public void testConverterMustache() {
-        List<TypeAttribute> typeAttributes = typeDao.getTypeAttributes(SAMPLE_TYPE_ONE);
+        List<TypeAttribute> typeAttributes = typeDao.getTypeAttributes(SAMPLE_TYPE_ONE, "OBRIDGE");
         Type t = new Type();
         t.setTypeName(SAMPLE_TYPE_ONE);
         t.setAttributeList(typeAttributes);

--- a/obridge-main/src/test/java/org/obridge/dao/TypeDaoTest.java
+++ b/obridge-main/src/test/java/org/obridge/dao/TypeDaoTest.java
@@ -27,7 +27,7 @@ public class TypeDaoTest extends BaseTest {
 
     @Test
     public void testGetTypeList() {
-        List<String> typeList = typeDao.getTypeList();
+        List<String> typeList = typeDao.getTypeList(null);
         Assert.assertTrue(typeList.contains(SAMPLE_TYPE_ONE));
         Assert.assertTrue(typeList.contains(SAMPLE_TYPE_TWO));
         Assert.assertFalse(typeList.contains(SAMPLE_TYPE_ONE_LIST));

--- a/obridge-main/src/test/java/org/obridge/mappers/PojoMapperTest.java
+++ b/obridge-main/src/test/java/org/obridge/mappers/PojoMapperTest.java
@@ -40,7 +40,7 @@ public class PojoMapperTest extends BaseTest {
     @Test
     public void testToPojo2() {
 
-        List<Procedure> simple_procedures = procedureDao.getAllProcedure("SIMPLE_PROCEDURES", null, "OBRIDGE");
+        List<Procedure> simple_procedures = procedureDao.getAllProcedure("SIMPLE_PROCEDURES", "OBRIDGE", null, null);
 
         Procedure ppp = null;
 
@@ -58,7 +58,7 @@ public class PojoMapperTest extends BaseTest {
 
     @Test
     public void testToPojo3() {
-        List<Procedure> simple_procedures = procedureDao.getAllProcedure("SIMPLE_PROCEDURES", null, "OBRIDGE");
+        List<Procedure> simple_procedures = procedureDao.getAllProcedure("SIMPLE_PROCEDURES", "OBRIDGE", null, null);
 
         Procedure ppp = null;
 

--- a/obridge-main/src/test/java/org/obridge/mappers/PojoMapperTest.java
+++ b/obridge-main/src/test/java/org/obridge/mappers/PojoMapperTest.java
@@ -28,7 +28,7 @@ public class PojoMapperTest extends BaseTest {
 
     @Test
     public void testToPojo() {
-        Pojo pojo = PojoMapper.typeToPojo(SAMPLE_TYPE_ONE, typeDao.getTypeAttributes(SAMPLE_TYPE_ONE));
+        Pojo pojo = PojoMapper.typeToPojo(SAMPLE_TYPE_ONE, typeDao.getTypeAttributes(SAMPLE_TYPE_ONE, "OBRIDGE"));
         Assert.assertEquals("SampleTypeOne", pojo.getClassName());
         Assert.assertEquals(9, pojo.getFields().size());
         for (PojoField f : pojo.getFields()) {

--- a/obridge-main/src/test/java/org/obridge/mappers/builders/CallStringBuilderTest.java
+++ b/obridge-main/src/test/java/org/obridge/mappers/builders/CallStringBuilderTest.java
@@ -12,7 +12,7 @@ public class CallStringBuilderTest extends BaseTest {
 
     @Before
     public void setUp() {
-        p = new ProcedureDao(ds).getAllProcedure(null, "SIMPLE_BOOLEAN_RETURN", "OBRIDGE").get(0);
+        p = new ProcedureDao(ds).getAllProcedure("SIMPLE_BOOLEAN_RETURN", "OBRIDGE", null, null).get(0);
     }
 
     @Test


### PR DESCRIPTION
Hi,

Here are the changes:
- Updated TypeDao so that queries are perfomed against all_ tables
- Added functionality to query database object names from a user defined table, so that it's possible to specify objects to generate java code for. Useful, when all only few objects are needed - works much faster this way.
- For this to work, the following config parameters were introduced:
```
    <projectName>PROJ1</projectName>
    <sourcesTableProc>POPULATE_MY_SOURCES</sourcesTableProc>
    <sourcesTable>MY_SOURCES</sourcesTable>

```
- **projectName** - name of the project used to query the user defined objects. Useful, if generator is used across several projects (See below).
- **sourcesTableProc** - Oracle procedure, which will called to populate the table. **projectName** will be passed to it as the only parameter.
- **sourcesTable** - name of the table, which **sourcesTableProc** populates.

It looks like this:

`create table MY_SOURCES (project_name varchar2(128), object_type varchar2(128), object_name varchar2(128));
`
```
CREATE OR REPLACE PROCEDURE populate_my_sources(pi_project_name IN VARCHAR2) IS
BEGIN
  DELETE FROM my_sources
   WHERE project_name = pi_project_name;
  INSERT INTO my_sources
    (project_name
    ,object_type
    ,object_name)
    SELECT pi_project_name
          ,'TYPE'
          ,type_name
      FROM user_types;
  INSERT INTO my_sources
    (project_name
    ,object_type
    ,object_name)
    SELECT pi_project_name
          ,'PACKAGE'
          ,object_name
      FROM user_objects
     WHERE object_type = 'PACKAGE';
  COMMIT;
END populate_my_sources;
```
